### PR TITLE
Case insensitive propertyfetcher

### DIFF
--- a/open_source_licenses.txt
+++ b/open_source_licenses.txt
@@ -1,6 +1,6 @@
 open_source_licenses.txt
 
-Wavefront by VMware ASP.Net Core SDK for C# 1.3.0 GA
+Wavefront by VMware ASP.Net Core SDK for C# 1.3.1 GA
 
 ======================================================================
 

--- a/src/Wavefront.AspNetCore.SDK.CSharp/Diagnostics/AspNetCoreDiagnostics.cs
+++ b/src/Wavefront.AspNetCore.SDK.CSharp/Diagnostics/AspNetCoreDiagnostics.cs
@@ -123,6 +123,11 @@ namespace Wavefront.AspNetCore.SDK.CSharp.Diagnostics
         private void OnHttpRequestInStart(object arg)
         {
             var httpContext = (HttpContext)_httpRequestIn_start_HttpContextFetcher.Fetch(arg);
+            if (httpContext == null)
+            {
+                Logger.LogInformation("No metrics/spans will be recorded because HttpContext payload is null");
+                return;
+            }
             var request = httpContext.Request;
 
             httpContext.Items[StartTimeMillisKey] = GetCurrentMillis();
@@ -150,8 +155,12 @@ namespace Wavefront.AspNetCore.SDK.CSharp.Diagnostics
             //       has been selected but no filters have run and model binding hasn't occured.
 
             var httpContext = (HttpContext)_beforeAction_httpContextFetcher.Fetch(arg);
-            var request = httpContext.Request;
             var actionDescriptor = (ActionDescriptor)_beforeAction_ActionDescriptorFetcher.Fetch(arg);
+            if (httpContext == null || actionDescriptor == null)
+            {
+                return;
+            }
+            var request = httpContext.Request;
             string routeTemplate = actionDescriptor.AttributeRouteInfo.Template;
             var controllerActionDescriptor = actionDescriptor as ControllerActionDescriptor;
             string controllerName = controllerActionDescriptor?.ControllerTypeInfo.FullName;
@@ -205,9 +214,13 @@ namespace Wavefront.AspNetCore.SDK.CSharp.Diagnostics
         private void OnAfterAction(object arg)
         {
             var httpContext = (HttpContext)_afterAction_httpContextFetcher.Fetch(arg);
+            var actionDescriptor = (ActionDescriptor)_afterAction_ActionDescriptorFetcher.Fetch(arg);
+            if (httpContext == null || actionDescriptor == null)
+            {
+                return;
+            }
             var request = httpContext.Request;
             var response = httpContext.Response;
-            var actionDescriptor = (ActionDescriptor)_afterAction_ActionDescriptorFetcher.Fetch(arg);
             string routeTemplate = actionDescriptor.AttributeRouteInfo.Template;
             var controllerActionDescriptor = actionDescriptor as ControllerActionDescriptor;
             string controllerName = controllerActionDescriptor?.ControllerTypeInfo.FullName;
@@ -262,6 +275,10 @@ namespace Wavefront.AspNetCore.SDK.CSharp.Diagnostics
         private void OnHttpRequestInStop(object arg)
         {
             var httpContext = (HttpContext)_httpRequestIn_stop_HttpContextFetcher.Fetch(arg);
+            if (httpContext == null)
+            {
+                return;
+            }
             var statusCode = httpContext.Response.StatusCode;
 
             IScope scope = Tracer.ScopeManager.Active;

--- a/src/Wavefront.AspNetCore.SDK.CSharp/Diagnostics/PropertyFetcher.cs
+++ b/src/Wavefront.AspNetCore.SDK.CSharp/Diagnostics/PropertyFetcher.cs
@@ -1,6 +1,7 @@
 ﻿// From https://github.com/opentracing-contrib/csharp-netcore/blob/master/src/OpenTracing.Contrib.NetCore/Internal/PropertyFetcher.cs
 
 using System;
+using System.Linq;
 using System.Reflection;
 
 namespace Wavefront.AspNetCore.SDK.CSharp.Diagnostics
@@ -28,7 +29,9 @@ namespace Wavefront.AspNetCore.SDK.CSharp.Diagnostics
             if (objType != _expectedType)
             {
                 TypeInfo typeInfo = objType.GetTypeInfo();
-                _fetchForExpectedType = PropertyFetch.FetcherForProperty(typeInfo.GetDeclaredProperty(_propertyName));
+                var propertyInfo = typeInfo.DeclaredProperties.FirstOrDefault(
+                    p => string.Equals(p.Name, _propertyName, StringComparison.InvariantCultureIgnoreCase));
+                _fetchForExpectedType = PropertyFetch.FetcherForProperty(propertyInfo);
                 _expectedType = objType;
             }
             return _fetchForExpectedType.Fetch(obj);

--- a/src/Wavefront.AspNetCore.SDK.CSharp/Wavefront.AspNetCore.SDK.CSharp.csproj
+++ b/src/Wavefront.AspNetCore.SDK.CSharp/Wavefront.AspNetCore.SDK.CSharp.csproj
@@ -4,7 +4,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>NU1701</NoWarn>
     <PackageId>Wavefront.AspNetCore.SDK.CSharp</PackageId>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Title>Wavefront by VMware ASP.NET Core SDK</Title>
     <Authors>Wavefront</Authors>
     <Description>This library provides support for reporting out of the box metrics, histograms, and tracing spans from your ASP.NET Core Web API or MVC application. The data is reported to Wavefront via proxy or direct ingestion and will help you understand how your application is performing in production.</Description>
@@ -13,7 +13,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/wavefrontHQ/wavefront-aspnetcore-sdk-csharp</RepositoryUrl>
     <PackageTags>Wavefront;VMware;monitoring;metrics;histogram;tracing;aspnetcore;aspnetcoremvc</PackageTags>
-    <PackageReleaseNotes>https://github.com/wavefrontHQ/wavefront-aspnetcore-sdk-csharp/releases/tag/v1.3.0</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/wavefrontHQ/wavefront-aspnetcore-sdk-csharp/releases/tag/v1.3.1</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="App.Metrics.AspNetCore" Version="2.0.0" />


### PR DESCRIPTION
For .NET Core 3.x, where diagnostics properties are now pascal case instead of camelcase.